### PR TITLE
Change declaration of a `_promise` to local scope, as intended

### DIFF
--- a/modules/gapi-client.js
+++ b/modules/gapi-client.js
@@ -27,7 +27,7 @@ angular.module('gapi.client', []).provider('gapi', function() {
 
     this.$get = ['$q', '$rootScope', '$window', function($q, $scope, $window) {
         var $gapi,
-            _deferred = $q.defer();
+            _deferred = $q.defer(),
             _promise = _deferred.promise;
 
         function resolve() {


### PR DESCRIPTION
With `_promise` left in global scope, this code breaks with `ReferenceError` after minification.
